### PR TITLE
Added a new getCurrentLocaleNative function

### DIFF
--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -408,6 +408,16 @@ class LaravelLocalization {
     }
 
     /**
+     * Returns current locale native name
+     *
+     * @return string current locale native name
+     */
+    public function getCurrentLocaleNative()
+    {
+        return $this->supportedLocales[ $this->getCurrentLocale() ][ 'native' ];
+    }
+
+    /**
      * Returns current locale direction
      *
      * @return string current locale direction


### PR DESCRIPTION
Added a new **```getCurrentLocaleNative```** function, there are times when you want to display the current locale in the user's native language.  If a user selects Deutsch (German) in a drop down menu to charge their language to german, once the locale has been set and changed the site's language displays everything in German but the **```getCurrentLocaleName```** displays the word German not Deutsch.  So in cases like this use **```getCurrentLocaleNative```** instead of **```getCurrentLocaleName```** would be ideal.